### PR TITLE
fix: adds support for dynamic validationSchema

### DIFF
--- a/example/AsyncForm.tsx
+++ b/example/AsyncForm.tsx
@@ -1,0 +1,138 @@
+import 'react-app-polyfill/ie11';
+import * as React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { TextField } from './components/TextField/TextField';
+import { Button } from './components/Button/Button';
+import * as Yup from 'yup';
+import { useForm } from '../.';
+import './index.css';
+
+interface User {
+  username: string;
+  email: string;
+  password?: string;
+}
+
+const validationSchema = (user: User | null) =>
+  Yup.object()
+    .shape({
+      username: Yup.string()
+        .required()
+        .min(4),
+      email: Yup.string()
+        .required()
+        .email(),
+      ...(user?.password && {
+        password: Yup.string()
+          .required('Password is required')
+          .min(10),
+      }),
+    })
+    .defined();
+
+const getUserAsync = (): Promise<User> => {
+  return new Promise(res => {
+    setTimeout(() => {
+      res({
+        username: 'The dude',
+        email: 'thedude@email.com',
+      });
+    }, 1200);
+  });
+};
+
+const useFetchUser = () => {
+  const [loading, setLoading] = useState(false);
+  const [user, setUser] = useState<User | null>(null);
+  useEffect(() => {
+    setLoading(true);
+    getUserAsync().then(user => {
+      setUser(user);
+      setLoading(false);
+    });
+  });
+
+  return { user, loading };
+};
+
+export const AsyncForm: React.FC = () => {
+  const userMounted = useRef(false);
+  const [addPassword, setAddPassword] = useState(false);
+  const { user } = useFetchUser();
+
+  const {
+    values,
+    errors,
+    isValid,
+    setValues,
+    reset,
+    onChange,
+    onSubmit,
+  } = useForm<User>({
+    initialValues: { username: '', email: '', password: '' },
+    validationSchema: validationSchema(
+      addPassword ? { ...user, password: '1234567890' } as User : user
+    ),
+    debounce: {
+      in: 1000,
+      out: 0,
+    },
+  });
+
+  useEffect(() => {
+    if (user && !userMounted.current) {
+      setValues(addPassword ? { ...user, password: '1234567890' } : user);
+      userMounted.current = true;
+    }
+  }, [user]);
+
+  const handleSubmit = formValues => {
+    console.log('formValues', formValues);
+  };
+
+  return (
+    <>
+      <div className="header">
+        <h3>User Form</h3>
+        <div className="button-wrapper">
+          <button onClick={reset}>reset form</button>
+        </div>
+      </div>
+      <form className="form" onSubmit={onSubmit(handleSubmit)}>
+        <TextField
+          id="username-input"
+          label="Username"
+          name="username"
+          type="text"
+          value={values.username}
+          error={errors?.username}
+          onChange={onChange}
+        />
+        <TextField
+          id="email-input"
+          label="Email"
+          name="email"
+          type="email"
+          value={values.email}
+          error={errors?.email}
+          onChange={onChange}
+        />
+        <TextField
+          id="password-input"
+          label="Password"
+          name="password"
+          type="password"
+          value={values.password}
+          error={errors?.password}
+          onChange={onChange}
+        />
+        <Button disabled={!isValid}>Submit</Button>
+      </form>
+      <div className="button-wrapper margin-top space-around">
+        <button onClick={() => setAddPassword(currentValue => !currentValue)}>
+          {addPassword ? 'remove' : 'add'} password
+        </button>
+      </div>
+    </>
+  );
+};

--- a/example/UserForm.tsx
+++ b/example/UserForm.tsx
@@ -44,8 +44,8 @@ export const UserForm: React.FC = () => {
     setValues({ username: 'foo', email: 'bar', password: 'password' });
   }, []);
 
-  const handleSubmit = () => {
-    console.log('values', values);
+  const handleSubmit = (formValues) => {
+    console.log('formValues', formValues);
   };
 
   return (

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,33 +1,12 @@
 import 'react-app-polyfill/ie11';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as Yup from 'yup';
+import { useState } from 'react';
 import './index.css';
 import { UserForm } from './UserForm';
 import { AddressForm } from './AddressForm';
-import { useState } from 'react';
-import { TextField } from './components/TextField/TextField';
+import { AsyncForm } from './AsyncForm';
 
-const regex = new RegExp('^((P(ost|ostal)?([ \\.]*O(ffice)?)?([ \\.]*Box)?)*$)', 'i');
-
-const validationSchema = Yup.object().shape({
-  name: Yup.string().required().max(5).matches(/(hi|bye)/),
-  email: Yup.string().required().email(),
-  password: Yup.string().required('Password is required'),
-  address1: Yup
-    .string()
-    .required()
-    .test('no-po-box', 'P.O. box is not allowed', (value) => !regex.test(value)),
-});
-
-type FormValues = Yup.InferType<typeof validationSchema>;
-
-const initialValues: FormValues = {
-  name: '',
-  email: '',
-  password: '',
-  address1: '',
-};
 
 const App = () => {
   const [activeLink, setActiveLink] = useState('user');
@@ -37,9 +16,11 @@ const App = () => {
       <div className="button-wrapper space-around">
         <a className="link" onClick={() => setActiveLink('user')}>User Form</a>
         <a className="link" onClick={() => setActiveLink('address')}>Address Form</a>
+        <a className="link" onClick={() => setActiveLink('async')}>Async Form</a>
       </div>
       {activeLink === 'user' && <UserForm />}
       {activeLink === 'address' && <AddressForm />}
+      {activeLink === 'async' && <AsyncForm />}
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/platypusrex/react-hook-form/issues"
   },
   "homepage": "https://github.com/platypusrex/react-hook-form#readme",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/form/useValidation.ts
+++ b/src/form/useValidation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { ObjectSchema } from 'yup';
 import {
   DebounceState,
@@ -35,10 +35,12 @@ export const useValidation = <TValues extends FormValue>(
   );
 
   const [errors, setErrors] = useState<Partial<TValues>>(
-    initialValidationState
+    () => initialValidationState
   );
-  const debouncersRef = useRef<DebounceState<TValues> | undefined>(
-    initialDebounceState
+
+  const debouncers = useMemo<DebounceState<TValues> | undefined>(
+    () => initialDebounceState,
+    [validationSchema]
   );
 
   const resetErrors = useCallback(() => {
@@ -54,7 +56,7 @@ export const useValidation = <TValues extends FormValue>(
           value,
           errors,
           setErrors,
-          debouncers: debouncersRef.current,
+          debouncers,
         });
       }
     },

--- a/src/form/useValidation.ts
+++ b/src/form/useValidation.ts
@@ -40,7 +40,7 @@ export const useValidation = <TValues extends FormValue>(
 
   const debouncers = useMemo<DebounceState<TValues> | undefined>(
     () => initialDebounceState,
-    [validationSchema, initialDebounceState]
+    [initialDebounceState]
   );
 
   const resetErrors = useCallback(() => {

--- a/src/form/useValidation.ts
+++ b/src/form/useValidation.ts
@@ -40,7 +40,7 @@ export const useValidation = <TValues extends FormValue>(
 
   const debouncers = useMemo<DebounceState<TValues> | undefined>(
     () => initialDebounceState,
-    [validationSchema]
+    [validationSchema, initialDebounceState]
   );
 
   const resetErrors = useCallback(() => {
@@ -60,7 +60,7 @@ export const useValidation = <TValues extends FormValue>(
         });
       }
     },
-    [errors, initialValidationState, validationSchema]
+    [errors, initialValidationState, validationSchema, debouncers]
   );
 
   return { errors, resetErrors, handleFieldValidation };


### PR DESCRIPTION
Swapping the use of `useRef` for `useMemo` in storing the initialized debouncer state for `useValidation`. The intention here is to still memoize the debouncer state, but also take advantage of `useMemo`'s dep array to support a dynamic update of `validationSchema`. 

In general I think this use case should be far less common, but it's certainly possible that you might need to base the shape of validation on some remote asynchronous data. I also added another example to demonstrate this use case.