### PR TITLE
fix: async validation debouncing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/platypusrex/react-hook-form/issues"
   },
   "homepage": "https://github.com/platypusrex/react-hook-form#readme",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/form/useValidation.ts
+++ b/src/form/useValidation.ts
@@ -48,7 +48,7 @@ export const useValidation = <TValues extends FormValue>(
     const fieldsRef = schemaRef.current
       ? Object.keys(schemaRef.current.fields)
       : [];
-    if (!fields.every((val, index) => val === fieldsRef[index])) {
+    if (!fields.every((val, i) => val === fieldsRef[i])) {
       debouncers.current = getInitialDebounceState(
         debounceTimers.current,
         validationSchema


### PR DESCRIPTION
Sincerely hoping this is the last time I'm having to address this. I had a difficult time reproducing this one and had to test from the app that was experiencing the issue. Added an side effect to essentially check whether the validation schema was updated after initialization. Code could probably be cleaned up but this at least seems to get things working properly. 