### PR TITLE
refactor: updates/breaking changes to form hook options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,13 @@ export const UserForm: React.FC = () => {
     onChange,
     onSubmit
   } = useForm<FormValues>({
-    validationSchema,
+    validation: {
+      schema: validationSchema,
+      debounce: { in: 500, out: 0 },
+    },
     initialValues: {
       email: '',
       password: '',
-    },
-    debounce: {
-      in: 500,
-      out: 0,
     },
   });
 
@@ -91,10 +90,10 @@ export const UserForm: React.FC = () => {
           id="email"
           type="email"
           name="email"
-          value={value.email}
+          value={values.email}
           onChange={onChange}
         />
-        {error && <p>{error.email}</p>}
+        {error && <p>{errors.email}</p>}
       </div>
       <div>
         <label htmlFor="password">{label}</label>
@@ -102,10 +101,10 @@ export const UserForm: React.FC = () => {
           id="password"
           type="password"
           name="password"
-          value={value.password}
+          value={values.password}
           onChange={onChange}
         />
-        {error && <p>{error.password}</p>}
+        {error && <p>{errors.password}</p>}
       </div>
       <button type="reset">Reset</button>
       <button type="submit" disabled={!isValid}>Submit</button>
@@ -120,15 +119,13 @@ The hook accepts a configuration object as input. Below is a table that represen
 
 | **Property** | **Type** | **Required** |
 | --- | --- | --- |
-| initialValues | object | yes |
-| validationSchema | Yup.ObjectSchema | no (recommended) |
-| debounce | number or { in: number; out: number; } |
+| initialValues | object (TValues) | yes |
+| validation | { schema: Yup.ObjectSchema<TValues>; debounce?: { in: number; out: number; }; } | no (recommended) |
 
 ```ts
 export interface UseFormConfig<TValues extends FormValue> {
   initialValues: TValues;
-  validationSchema?: ValidationSchema<TValues>;
-  debounce?: DebounceValidation;
+  validation?: Validation<TValues>;
 }
 ```
 
@@ -136,18 +133,20 @@ export interface UseFormConfig<TValues extends FormValue> {
 
 The only required input for using the form hook. This represents the form initial state and is always required
 
-`validationSchema`
+`validation`
 
-A Yup schema object for validating your form. If the validation schema is not provided you are essentially opting out
-of validating your form. Handling change and form submission events will still function as intended.
+The validation object is an optional object that is used to validate form state. If the validation schema is not provided
+you are essentially opting out of validating your form. Handling change and form submission events will still function as normal.
 
+<small>`schema`</small></br>
+If the validation object is provided, a `schema` property is required. This must be a Yup schema object.
+
+<small>`debounce`</small></br>
 `debounce`
-
-Value(s) in milliseconds for validation debounce. The debounce property is only relevant if you have provided a `validationSchema`.
-A warning will be presenting in your development env if provided without validation. If a `number` primitive is provided, the debounce
-will occur when an error occurs and also when an error is resolved by the user's input. You can fine tune the debounce behavior by
-provided an object with `in` and `out` properties. Debouncing `in` will delay validation for the given time while `out` will debounce
-the correction.
+You may optionally provide a `debounce` property as well. If provided this debounce will be applied to the validation of any form state property.
+The debounce value(s) should be expressed in milliseconds. If a `number` primitive is provided, the debounce will occur when an error
+occurs and also when an error is resolved by the user's input. You can fine tune the debounce behavior by provided an object with `in` and `out`
+properties. Debouncing `in` will delay validation  while `out` will debounce the correction.
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The hook accepts a configuration object as input. Below is a table that represen
 | **Property** | **Type** | **Required** |
 | --- | --- | --- |
 | initialValues | object (TValues) | yes |
-| validation | { schema: Yup.ObjectSchema<TValues>; debounce?: { in: number; out: number; }; } | no (recommended) |
+| validation | { schema: Yup.ObjectSchema<TValues>; debounce?: { in: number; out: number; } } | no (recommended) |
 
 ```ts
 export interface UseFormConfig<TValues extends FormValue> {

--- a/example/AddressForm.tsx
+++ b/example/AddressForm.tsx
@@ -11,7 +11,7 @@ import './index.css';
 const pobox = /\bP(ost|ostal)?([ \.]*(O|0)(ffice)?)?([ \.]*Box)\b/i;
 const alpha = /^[^!@#$%^&*()<>:;"'{}[\]|+=?/\\_]*$/;
 
-const validationSchema = object({
+const schema = object({
   address1: string()
     .required()
     .test('no-po-box', 'P.O. box is not allowed', (value) => !pobox.test(value!))
@@ -22,7 +22,7 @@ const validationSchema = object({
   zip: string().required().min(5).max(5),
 });
 
-type FormValues = InferType<typeof validationSchema>;
+type FormValues = InferType<typeof schema>;
 
 const initialValues: FormValues = {
   address1: '',
@@ -43,10 +43,9 @@ export const AddressForm: React.FC = () => {
     onSubmit
   } = useForm<FormValues>({
     initialValues,
-    validationSchema,
-    debounce: {
-      in: 1000,
-      out: 0,
+    validation: {
+      schema,
+      debounce: { in: 1000, out: 0 },
     },
   });
 

--- a/example/AsyncForm.tsx
+++ b/example/AsyncForm.tsx
@@ -21,11 +21,13 @@ const validationSchema = (user: User | null) =>
     email: string()
       .required()
       .email(),
-    ...(user?.password && {
-      password: string()
-        .required('Password is required')
-        .min(10),
-    }),
+    ...(!user?.password
+      ? { password: string().min(10) }
+      : {
+          password: string()
+            .required('Password is required')
+            .min(10),
+        }),
   });
 
 const getUserAsync = (): Promise<User> => {
@@ -68,12 +70,11 @@ export const AsyncForm: React.FC = () => {
     onSubmit,
   } = useForm<User>({
     initialValues: { username: '', email: '', password: '' },
-    validationSchema: validationSchema(
-      addPassword ? { ...user, password: '1234567890' } as User : user
-    ),
-    debounce: {
-      in: 1000,
-      out: 0,
+    validation: {
+      schema: validationSchema(
+        addPassword ? ({ ...user, password: '1234567890' } as User) : user
+      ),
+      debounce: { in: 1000, out: 0 },
     },
   });
 

--- a/example/UserForm.tsx
+++ b/example/UserForm.tsx
@@ -7,13 +7,13 @@ import { Button } from './components/Button/Button';
 import { useForm } from '../.';
 import './index.css';
 
-const validationSchema = object({
+const schema = object({
   username: string().required().min(4),
   email: string().required().email(),
   password: string().required('Password is required').min(10),
 });
 
-type FormValues = InferType<typeof validationSchema>;
+type FormValues = InferType<typeof schema>;
 
 const initialValues: FormValues = {
   username: '',
@@ -33,10 +33,9 @@ export const UserForm: React.FC = () => {
     onSubmit
   } = useForm<FormValues>({
     initialValues,
-    validationSchema,
-    debounce: {
-      in: 1000,
-      out: 0,
+    validation: {
+      schema,
+      debounce: { in: 1000, out: 0 },
     },
   });
 

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     }
   ],
   "peerDependencies": {
-    "react": ">=16",
-    "yup": "1.*"
+    "react": ">=16"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.0.2",
@@ -68,14 +67,14 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "size-limit": "^7.0.5",
+    "standard-version": "^9.3.2",
     "tsdx": "^0.14.1",
     "tslib": "^2.3.1",
-    "typescript": "^4.5.4",
-    "yup": "^1.0.0-beta.1"
+    "typescript": "^4.5.4"
   },
   "dependencies": {
     "lodash.debounce": "^4.0.8",
-    "standard-version": "^9.3.2"
+    "yup": "^1.0.0-beta.1"
   },
   "resolutions": {
     "typescript": "4.5.4"

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,2 @@
-export const DEBOUNCE_WARNING =
-  'useForm: debounce provided without a validation schema. This property is only intended to be used in conjunction with a validation schema.';
 export const HANDLE_SET_FORM_VALUES_WARNING =
   'setFormValues: validation of fields will not be performed unless a validation schema is provided.';

--- a/src/form/useForm.ts
+++ b/src/form/useForm.ts
@@ -1,26 +1,23 @@
 import { FormEvent, useCallback, useMemo } from 'react';
 import { useValues } from './useValues';
 import { useValidation } from './useValidation';
-import { DEBOUNCE_WARNING } from '../constants';
 import {
   getInputNameAndValue,
   handleSetFormValues,
   useEventCallback,
 } from '../utils';
 import {
-  DebounceValidation,
   FormError,
   FormValue,
   OnChangeEvent,
   SetFormValue,
   SetFormValues,
-  ValidationSchema,
+  Validation,
 } from '../types';
 
 export interface UseFormConfig<TValues extends FormValue> {
   initialValues: TValues;
-  validationSchema?: ValidationSchema<TValues>;
-  debounce?: DebounceValidation;
+  validation?: Validation<TValues>;
 }
 
 export interface UseForm<TValues extends FormValue> {
@@ -36,8 +33,7 @@ export interface UseForm<TValues extends FormValue> {
 
 export const useForm = <TValues extends FormValue>({
   initialValues,
-  validationSchema,
-  debounce,
+  validation,
 }: UseFormConfig<TValues>): UseForm<TValues> => {
   const {
     values,
@@ -47,14 +43,10 @@ export const useForm = <TValues extends FormValue>({
   } = useValues(initialValues);
 
   const { errors, resetErrors, handleFieldValidation } = useValidation(
-    validationSchema,
-    debounce
+    validation
   );
 
-  if (__DEV__ && debounce && !validationSchema) {
-    console.warn(DEBOUNCE_WARNING);
-  }
-
+  const { schema: validationSchema } = validation ?? {};
   const isValid = useMemo(
     () => (validationSchema ? validationSchema.isValidSync(values) : true),
     [validationSchema, values]

--- a/src/form/useValidation.ts
+++ b/src/form/useValidation.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   DebounceState,
-  DebounceValidation,
   DebounceValidationObj,
   FormError,
   FormValue,
-  ValidationSchema,
+  Validation,
 } from '../types';
 import {
   getDebounceTimers,
@@ -21,9 +20,9 @@ export interface UseValidation<TValues extends FormValue> {
 }
 
 export const useValidation = <TValues extends FormValue>(
-  validationSchema?: ValidationSchema<TValues>,
-  debounce?: DebounceValidation
+  validation?: Validation<TValues>
 ): UseValidation<TValues> => {
+  const { schema: validationSchema, debounce } = validation ?? {};
   const schemaRef = useRef(validationSchema);
   const debounceTimers = useRef<DebounceValidationObj>(
     getDebounceTimers(debounce)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,8 +16,6 @@ export type InputChangeEvent = ChangeEvent<any>;
 
 export type OnChangeEvent = InputChangeEvent | NameAndValue;
 
-export type ValidationSchema<TSchema> = ObjectSchema<TSchema>;
-
 export type HandleValidateField<TValues extends FormValue> = (
   name: string,
   value: any,
@@ -39,13 +37,6 @@ export type SetFormValue<TValues extends FormValue> = (
   shouldValidate?: boolean
 ) => void;
 
-export interface DebounceValidationObj {
-  in: number;
-  out: number;
-}
-
-export type DebounceValidation = number | DebounceValidationObj;
-
 interface Cancelable {
   cancel(): void;
   flush(): void;
@@ -62,3 +53,17 @@ export type DebounceState<TValue> = {
     [key in keyof TValue]: any;
   };
 };
+
+export interface DebounceValidationObj {
+  in: number;
+  out: number;
+}
+
+export type DebounceValidation = number | DebounceValidationObj;
+
+export type ValidationSchema<TSchema> = ObjectSchema<TSchema>;
+
+export interface Validation<TValues extends FormValue> {
+  schema: ValidationSchema<TValues>;
+  debounce?: DebounceValidation;
+}

--- a/src/utils/getDebounceTimers.ts
+++ b/src/utils/getDebounceTimers.ts
@@ -1,19 +1,9 @@
 import { DebounceValidation, DebounceValidationObj } from '../types';
 
 export const getDebounceTimers = (
-  debounceValidation?: DebounceValidation
+  debounce: DebounceValidation = 0
 ): DebounceValidationObj => {
-  if (!debounceValidation) {
-    return {
-      in: 0,
-      out: 0,
-    };
-  } else if (typeof debounceValidation === 'number') {
-    return {
-      in: debounceValidation,
-      out: debounceValidation,
-    };
-  } else {
-    return debounceValidation;
-  }
+  return typeof debounce !== 'number'
+    ? debounce
+    : { in: debounce, out: debounce };
 };

--- a/src/utils/getInitialDebounceState.ts
+++ b/src/utils/getInitialDebounceState.ts
@@ -1,13 +1,13 @@
 import { debounceValidationFn } from './debounceValidationFn';
 import {
   DebounceState,
-  DebounceValidation,
+  DebounceValidationObj,
   FormValue,
   ValidationSchema,
 } from '../types';
 
 export const getInitialDebounceState = <TValues extends FormValue>(
-  debounceTiming: DebounceValidation,
+  debounceTiming: DebounceValidationObj,
   validationSchema?: ValidationSchema<TValues>
 ): DebounceState<TValues> | undefined => {
   if (!validationSchema) {
@@ -16,7 +16,6 @@ export const getInitialDebounceState = <TValues extends FormValue>(
 
   return Object.keys(debounceTiming).reduce((acc, curr) => {
     const timing = debounceTiming[curr as keyof typeof debounceTiming];
-    // @ts-ignore
     acc[curr] = Object.keys(validationSchema.describe().fields).reduce(
       (acc, curr) => {
         acc[curr] = debounceValidationFn(timing);

--- a/test/useForm.test.ts
+++ b/test/useForm.test.ts
@@ -1,7 +1,6 @@
 import { renderHook, act, cleanup } from '@testing-library/react-hooks';
 import { eventObject, formValues, validationSchema } from './testUtils';
 import { useForm } from '../src/form/useForm';
-import { DEBOUNCE_WARNING } from '../src/constants';
 import { OnChangeEvent } from '../src/types';
 
 describe('useForm', () => {
@@ -11,7 +10,7 @@ describe('useForm', () => {
     const { result } = renderHook(() =>
       useForm({
         initialValues: formValues,
-        validationSchema,
+        validation: { schema: validationSchema },
       })
     );
 
@@ -30,17 +29,17 @@ describe('useForm', () => {
     });
   });
 
-  it('should throw a dev warning if passed debounce arg but no validationSchema', () => {
-    const spyWarn = jest.spyOn(console, 'warn');
-    renderHook(() =>
-      useForm({
-        initialValues: formValues,
-        debounce: 500,
-      })
-    );
-
-    expect(spyWarn).toHaveBeenCalledWith(DEBOUNCE_WARNING);
-  });
+  // it('should throw a dev warning if passed debounce arg but no validationSchema', () => {
+  //   const spyWarn = jest.spyOn(console, 'warn');
+  //   renderHook(() =>
+  //     useForm({
+  //       initialValues: formValues,
+  //       debounce: 500,
+  //     })
+  //   );
+  //
+  //   expect(spyWarn).toHaveBeenCalledWith(DEBOUNCE_WARNING);
+  // });
 
   it('should return isValid true if no validationSchema is provided', () => {
     const { result } = renderHook(() =>
@@ -74,7 +73,7 @@ describe('useForm', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useForm({
         initialValues: formValues,
-        validationSchema,
+        validation: { schema: validationSchema },
       })
     );
 
@@ -119,7 +118,7 @@ describe('useForm', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useForm({
         initialValues: formValues,
-        validationSchema,
+        validation: { schema: validationSchema },
       })
     );
 
@@ -152,7 +151,7 @@ describe('useForm', () => {
     const { result } = renderHook(() =>
       useForm({
         initialValues,
-        validationSchema,
+        validation: { schema: validationSchema },
       })
     );
 
@@ -240,7 +239,7 @@ describe('useForm', () => {
     const { result, waitForNextUpdate } = renderHook(() =>
       useForm({
         initialValues: formValues,
-        validationSchema,
+        validation: { schema: validationSchema },
       })
     );
 
@@ -278,7 +277,6 @@ describe('useForm', () => {
     const { result } = renderHook(() =>
       useForm({
         initialValues: formValues,
-        debounce: 500,
       })
     );
 


### PR DESCRIPTION
Refactoring of the hook options by grouping yup validation schema and debounce as properties of a single `validation` object. This is the bulk of the refactor and represents a breaking change.

The example app was updated due to API changes, unit tests were fixed, and the README has been updated as well.